### PR TITLE
fix(point-figure): fill a falling box at the level price reached

### DIFF
--- a/src/transform/point-figure.ts
+++ b/src/transform/point-figure.ts
@@ -191,8 +191,24 @@ export class PointFigureTransform implements ISeriesTransform {
       return [];
     }
 
+    // Which box each direction has filled.
+    //
+    // A box index is the level the box sits on: index `n` is the box whose
+    // bottom edge is `n * box`. Rising, price fills index `n` by reaching
+    // `n * box` from below, so the highest index a rise has filled is
+    // `floor(price / box)`. Falling, price fills index `n` by reaching that
+    // same edge from *above*, which `floor` reports a box too early: a price
+    // sitting inside a box has not come down to its foot.
+    //
+    // Using `floor` both ways drew boxes at levels price never reached -- a
+    // close of 11.80 reversing a column topped at 15 printed Os at 14, 13, 12
+    // and 11, and a close of 49.80 under a column footed at 50 extended it to
+    // 49 on a bar a three-box chart should have left untouched. It also turned
+    // a column a box early, at 12.99 rather than at 12.00. Every level read off
+    // this chart is measured from a column's edges, so a box drawn at a price
+    // that never traded puts stops and targets where the market never went.
     const hb = Math.floor(upPrice / this._box);
-    const lb = Math.floor(downPrice / this._box);
+    const lb = Math.ceil(downPrice / this._box);
 
     // Direction not established yet: the first real move sets it, still with no
     // column emitted. Ties (an outside bar) resolve up, the classic convention.
@@ -217,7 +233,7 @@ export class PointFigureTransform implements ISeriesTransform {
         out.push(this._column());
         this._box = this._resolveBox(downPrice);
         this._top = Math.ceil(boundary / this._box) - 1;
-        this._bot = Math.floor(downPrice / this._box);
+        this._bot = Math.ceil(downPrice / this._box);
         this._dir = -1;
         this._time = bar.time;
       }

--- a/tests/transforms.test.ts
+++ b/tests/transforms.test.ts
@@ -83,6 +83,57 @@ describe('Point & Figure', () => {
     expect(out[1].close).toBeLessThan(out[1].open); // O (down)
   });
 
+  /**
+   * A box is filled by price reaching its level, not by price sitting inside
+   * it. The four cases below are the standard desk checks at box 1, reversal 3.
+   */
+  it('fills a rise up to the box price reached, and no further', () => {
+    T = 1;
+    // 10.50 is inside the box already filled; 11.20 fills the box at 11.
+    const out = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3, method: 'close' }), closes([5, 10.5, 10.5, 11.2]));
+    expect(out).toHaveLength(1);
+    expect(out[0].high).toBe(12); // exclusive top edge of the box at 11
+  });
+
+  it('fills a fall down to the level price reached, and no further', () => {
+    T = 1;
+    // A column topped at 15 reversing on 11.80: Os at 14, 13 and 12. Price has
+    // not come to 11, so no O is drawn there.
+    const out = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3, method: 'close' }), closes([10, 15.5, 13.5, 11.8]));
+    expect(out).toHaveLength(2);
+    expect(cols(out)[1].low).toBe(12);
+    expect(cols(out)[1].boxes).toBe(3);
+  });
+
+  it('draws nothing while price stays between the two levels', () => {
+    T = 1;
+    // A column footed at 50 needs 49 to extend and 53 to reverse. None of the
+    // chop reaches either, so the chart must not move -- 49.80 included.
+    const quiet = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3, method: 'close' }), closes([55, 50]));
+    T = 1;
+    const chopped = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3, method: 'close' }), closes([55, 50, 50.5, 52.1, 49.8, 51.5, 52.95]));
+    expect(chopped.map(oc)).toEqual(quiet.map(oc));
+  });
+
+  it('turns the column at the reversal level, not a box before it', () => {
+    T = 1;
+    // Topped at 15, three boxes down is 12.00. 12.99 is inside the box above.
+    const held = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3, method: 'close' }), closes([10, 15.5, 12.99]));
+    expect(held).toHaveLength(1);
+    T = 1;
+    const turned = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3, method: 'close' }), closes([10, 15.5, 12]));
+    expect(turned).toHaveLength(2);
+  });
+
+  it('fills every box of an oversized gap in one update', () => {
+    T = 1;
+    // Topped at 100, gapping to 90: Os from 99 down to 90.
+    const out = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3, method: 'close' }), closes([95, 100.5, 90]));
+    expect(out).toHaveLength(2);
+    expect(cols(out)[1].low).toBe(90);
+    expect(cols(out)[1].boxes).toBe(10);
+  });
+
   it('emits no phantom zero-height column when the first move is down', () => {
     T = 1;
     const out = runTransform(new PointFigureTransform({ boxSize: 1, reversal: 3 }), closes([100, 99, 98, 96, 95]));


### PR DESCRIPTION
## The bug

`PointFigureTransform.push` indexes both directions with `Math.floor(price / box)`.

Rising, that is the rule the chart type is defined by: a box is filled once price *reaches* its level, so a close of 11.20 fills the box at 11. Falling, the same expression fills the box price is merely *inside*.

At box 1.00, three-box reversal, close method:

| Case | Drawn today | Should be |
| --- | --- | --- |
| Close 11.80 reversing a column topped at 15 | Os at 14, 13, 12 **and 11** | Os at 14, 13, 12 |
| Close 49.80 under a column footed at 50 | column extended to **49** | nothing drawn |
| Fall from a top of 15 | turns at **12.99** | turns at 12.00 |

The second one is the clearest: a three-box chart whose column foot is 50 has a continuation level of 49 and a reversal level of 53. Price closing at 49.80 has reached neither, so the chart must not move — that "do nothing" behaviour is a large part of what P&F is for.

Every level a trader reads off this chart is measured from a column's edges — a stop under the foot, a target a box beyond the top — so a box drawn at a price that never traded puts those levels where the market never went.

## The fix

One-sided. A box index is the level the box sits on: index `n` is the box whose bottom edge is `n * box`. A rise fills index `n` by reaching `n * box` from below, so `floor` is right. A fall fills it by reaching that same edge from *above*, so the deepest box a fall fills is `ceil(price / box)`.

`floor` for `hb`, `ceil` for `lb` and for the `_bot` set when an X column turns. Both reversal thresholds are expressed in those indices, so the turn now lands on the reversal level exactly, with no separate change.

## Tests

Five standard desk checks added to `tests/transforms.test.ts`: continuation, reversal, noise filtering between the two levels, the turn landing on the level rather than a box early, and an oversized gap filling every box in one update.

The existing suite is untouched and passes: **4004 tests**, plus `npm run typecheck` and `npm run lint` clean.

## Provenance

Found while building a point-and-figure trading surface on top of this package: an indicator measuring entries and stops in boxes put a stop one box beyond where the column actually was, which traced back to the column foot itself. Verified against the engine scenario by scenario before touching it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes point-figure falling boxes so price must reach a box level to fill it, matching how rising boxes already work. Existing charts may redraw some falling columns, but only where the old logic drew boxes at prices that never traded.

**Bug Fixes**
- Falling columns now fill down to `ceil(price / box)` instead of `floor`.
- Reversals land on the reversal level exactly instead of one box early.
- Adds tests for continuation, reversal, noise filtering, turn placement, and oversized gaps.

<sup>Written for commit 3cf64ac7e732d84558759de653fb8ca66ff6a9a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo-charts/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

