### PR TITLE
Keep DOM grouping independent of candle charts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,14 @@ jobs:
         run: |
           npm install
           npm run build
+      - name: Verify independent depth demo in a browser
+        run: |
+          npx playwright install --with-deps chromium
+          node website/scripts/serve-preview.mjs 4174 &
+          depth_preview_pid=$!
+          trap 'kill "$depth_preview_pid"' EXIT
+          curl --retry 10 --retry-connrefused --retry-delay 1 --fail --silent http://127.0.0.1:4174/openalgo-charts/docs/depth-of-market/ > /dev/null
+          node scripts/check-depth-demo.mjs
 
   e2e:
     name: playwright smoke (real browser)

--- a/README.md
+++ b/README.md
@@ -249,32 +249,48 @@ Order, position, and bracket lines with live P&amp;L, one-click and drag-to-modi
 
 [Try the depth ladder](https://marketcalls.github.io/openalgo-charts/docs/depth-of-market/)
 with continuously simulated bids and asks, pause/resume, 5/20/200 depth levels,
-and configurable price grouping. The
+and configurable price grouping independent of the candlestick chart's scale.
+Try option candles with an option ladder, or spot candles with a separate ATM
+call ladder. The
 [drawing playground](https://marketcalls.github.io/openalgo-charts/docs/drawing-tools/)
 also lets you place, select, move, delete, undo and redo drawings.
 
 ```html
 <div id="depth-chart" style="height: 440px"></div>
+<div style="max-height: 440px; overflow: auto">
+  <table>
+    <thead><tr><th>Bid qty</th><th>Price</th><th>Ask qty</th></tr></thead>
+    <tbody id="depth-rows"></tbody>
+  </table>
+</div>
 ```
 
 ```ts
 import { createChart, darkTheme, generateBars } from 'openalgo-charts';
-import { DomLadder, FakeBroker } from 'openalgo-charts/trade';
+import { buildRows, FakeBroker } from 'openalgo-charts/trade';
 
 const chart = createChart(document.getElementById('depth-chart')!, { theme: darkTheme });
 const bars = generateBars(1700000000, 120, 60);
 chart.addSeries('candlestick').setData(bars);
 chart.timeScale.fitContent(bars.length);
 const mid = Math.round(bars.at(-1)!.close / 0.05) * 0.05;
-const ladder = new DomLadder({ tickSize: 0.05, groupBy: 20, width: 180, maxRows: 40 });
-chart.addPrimitive(ladder);
-chart.panes()[0].priceScale.setPriceRange({ min: mid - 12, max: mid + 12 });
-chart.setPriceAxisAutoFit(0, 'right', false);
+const bookRows = document.getElementById('depth-rows')!;
+let groupBy = 20; // Change this to regroup the ladder; the chart keeps its own scale.
 
 let step = 0;
 function updateDepth() {
   const price = mid + Math.round(Math.sin(step++ / 8) * 4) * 0.05;
-  ladder.setDepth(FakeBroker.makeDepth(price, 200, 0.05));
+  const depth = FakeBroker.makeDepth(price, 200, 0.05);
+  bookRows.replaceChildren(...buildRows(depth, 0.05, groupBy).map(row => {
+    const tr = document.createElement('tr');
+    for (const text of [String(row.bidQty), row.price.toFixed(2), String(row.askQty)]) {
+      const td = document.createElement('td');
+      td.textContent = text;
+      td.style.height = '28px';
+      tr.append(td);
+    }
+    return tr;
+  }));
 }
 updateDepth();
 const timer = setInterval(updateDepth, 750);
@@ -290,7 +306,10 @@ function dispose() {
 per display row. Here, 20 × 0.05 creates 1.00-point rows. Quantities are summed
 into the nearest price bucket, with bids and asks kept separate. Grouping changes
 the display; it does not change the instrument's valid order prices. With a real
-feed, pass each supplied order-book snapshot to `ladder.setDepth(depth)`.
+feed, pass each supplied order-book snapshot to `buildRows`. Chart candles and
+ladder depth can come from separate instrument subscriptions. `DomLadder` remains
+available for an attached ladder that aligns to the chart's own price scale;
+see the guide for both integration patterns.
 
 ### Profiles &amp; order flow
 Volume Profile, Market Profile (TPO), Footprint, and cumulative delta.

--- a/scripts/check-depth-demo.mjs
+++ b/scripts/check-depth-demo.mjs
@@ -1,6 +1,7 @@
 /** Exercise the published API through the website's simulated depth demo. */
 import { strict as assert } from 'node:assert';
 import { mkdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { chromium, expect } from '@playwright/test';
 
 const base = (process.argv[2] ?? 'http://127.0.0.1:4174/openalgo-charts').replace(/\/$/, '');
@@ -60,27 +61,63 @@ try {
   const totals = rows => rows.reduce((sum, row) => [sum[0] + row.bid, sum[1] + row.ask], [0, 0]);
   const raw = await readBook();
   assert.equal(raw.length, 40, '20 source levels per side should display 40 raw rows');
+  const bookBounds = await demo.getByLabel('Scrollable depth rows').boundingBox();
+  const headerBounds = await demo.getByRole('columnheader', { name: 'Bid qty' }).boundingBox();
+  assert.ok(headerBounds.y >= bookBounds.y && headerBounds.y < bookBounds.y + 32, 'Column headings must stay visible when the book is scrolled to its centre');
+  await page.mouse.move(0, 0);
+  await page.waitForTimeout(150);
+  const chartPixels = async () => createHash('sha256').update(await demo.locator('.depth-chart canvas').first().evaluate(canvas => canvas.toDataURL())).digest('hex');
+  const originalChart = await chartPixels();
   for (const step of ['0.25', '0.50', '1.00']) {
-    await demo.locator('canvas').evaluateAll(canvases => canvases.forEach(canvas => window.__depthCanvasText.delete(canvas)));
     await demo.getByLabel('Display row size').selectOption(step);
     const grouped = await readBook();
     assert.ok(grouped.length < raw.length, 'Larger display rows must aggregate the supplied book');
     assert.deepEqual(totals(grouped), totals(raw), 'Grouping must preserve both side totals');
     assert.ok(grouped.every(row => Math.abs(row.price / Number(step) - Math.round(row.price / Number(step))) < 1e-7));
     assert.equal(await snapshot.textContent(), paused, 'Changing grouping must preserve the paused snapshot');
-    const largest = String(Math.max(...grouped.flatMap(row => [row.bid, row.ask])));
-    await expect.poll(() => demo.locator('canvas').evaluateAll(canvases =>
-      canvases.flatMap(canvas => Array.from(window.__depthCanvasText.get(canvas) ?? []))
-    )).toContain(largest);
+    await page.waitForTimeout(150);
+    assert.equal(await chartPixels(), originalChart, 'Ladder grouping must not change the candle chart or its price scale');
   }
 
   await demo.getByLabel('Display row size').selectOption('0.05');
   assert.deepEqual(await readBook(), raw, 'Returning to the source tick must restore the original rows');
+  const chartBounds = await demo.locator('.depth-chart').boundingBox();
+  await page.mouse.move(chartBounds.x + chartBounds.width - 20, chartBounds.y + 140);
+  await page.mouse.down();
+  await page.mouse.move(chartBounds.x + chartBounds.width - 20, chartBounds.y + 210, { steps: 6 });
+  await page.mouse.up();
+  await page.mouse.move(0, 0);
+  await page.waitForTimeout(150);
+  const manuallyScaled = await chartPixels();
+  assert.notEqual(manuallyScaled, originalChart, 'The regression check must start with a manually adjusted price scale');
+  await demo.getByLabel('Display row size').selectOption('0.50');
+  await page.waitForTimeout(150);
+  assert.equal(await chartPixels(), manuallyScaled, 'Grouping must preserve a manually adjusted price scale');
+  await demo.getByLabel('Display row size').selectOption('0.05');
+  await demo.locator('canvas').evaluateAll(canvases => canvases.forEach(canvas => window.__depthCanvasText.delete(canvas)));
+  await demo.getByLabel('Chart and ladder').selectOption('spot-option');
+  await expect(demo.getByText('NIFTY spot · candlesticks', { exact: true })).toBeVisible();
+  await expect.poll(chartPixels).not.toBe(originalChart);
+  await expect.poll(() => demo.locator('.depth-chart canvas').evaluateAll(canvases =>
+    canvases.flatMap(canvas => Array.from(window.__depthCanvasText.get(canvas) ?? []))
+      .some(text => /^24,?0\d\d(?:\.\d+)?$/.test(text))
+  )).toBe(true);
+  assert.deepEqual(await readBook(), raw, 'Changing the chart instrument must preserve the independent option book');
+  await page.waitForTimeout(150);
+  const spotChart = await chartPixels();
+  await demo.getByLabel('Display row size').selectOption('1.00');
+  await page.waitForTimeout(150);
+  assert.equal(await chartPixels(), spotChart, 'Option grouping must not rescale a spot chart');
+  await demo.getByLabel('Display row size').selectOption('0.05');
   for (const levels of ['5', '200']) {
     await demo.getByLabel('Depth levels per side').selectOption(levels);
     assert.equal((await readBook()).length, Number(levels) * 2);
     assert.equal(await snapshot.textContent(), paused, 'Depth selection must not restart a paused simulation');
+    await page.waitForTimeout(150);
+    assert.equal(await chartPixels(), spotChart, 'Depth selection must not alter the chart');
   }
+  await demo.getByLabel('Chart and ladder').selectOption('option-option');
+  await expect(demo.getByText('NIFTY ATM CE · candlesticks', { exact: true })).toBeVisible();
   await demo.getByLabel('Display row size').selectOption('0.50');
   const pick = demo.getByRole('button', { name: /^Inspect bid at / }).first();
   await pick.click();
@@ -118,7 +155,7 @@ try {
   assert.equal(await page.evaluate(() => performance.timeOrigin), origin, 'Lifecycle check must navigate within the same document');
   assert.equal(await page.evaluate(() => window.__depthTimers.size), 0, 'Unmount must clear the simulation timer');
   assert.deepEqual(errors, []);
-  console.log('Depth demo checks passed: changing quantities, pause/resume, quantity-preserving canvas and table grouping, 5/20/200 levels, row inspection, light/dark themes, mobile layout and timer cleanup.');
+  console.log('Depth demo checks passed: independent candle/ladder scales, option and spot scenarios, changing quantities, pause/resume, quantity-preserving grouping, 5/20/200 levels, row inspection, themes, mobile layout and timer cleanup.');
 } finally {
   await browser.close();
 }

--- a/website/components/DepthLadderDemo.tsx
+++ b/website/components/DepthLadderDemo.tsx
@@ -1,10 +1,30 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from 'next-themes';
 import type { MarketDepth } from '../../src/feed/types';
+import type { Bar } from '../../src/model/bar';
 import type { LadderRow } from '../../src/trade/dom-ladder';
 
 const TICK_SIZE = 0.05;
 const UPDATE_MS = 750;
+type Scenario = 'option-option' | 'spot-option';
+
+function chartClose(sequence: number, scenario: Scenario): number {
+  return scenario === 'spot-option'
+    ? Math.round((24000 + Math.sin(sequence / 13) * 18 + Math.sin(sequence / 4) * 5) * 100) / 100
+    : (2000 + Math.round(Math.sin(sequence / 8) * 3)) * TICK_SIZE;
+}
+
+function chartBar(sequence: number, scenario: Scenario): Bar {
+  const open = chartClose(sequence - 1, scenario);
+  const close = chartClose(sequence, scenario);
+  const wick = scenario === 'spot-option' ? 2.5 : TICK_SIZE;
+  return {
+    time: 1700000000 + (sequence + 80) * 60,
+    open, close,
+    high: Math.max(open, close) + wick,
+    low: Math.min(open, close) - wick,
+  };
+}
 
 function makeDepth(frame: number, levels: number): MarketDepth {
   const centreTick = 2000 + Math.round(Math.sin(frame / 8) * 3);
@@ -17,11 +37,11 @@ function makeDepth(frame: number, levels: number): MarketDepth {
 }
 
 interface DemoRuntime {
-  render: (depth: MarketDepth, frame: number, groupBy: number) => LadderRow[];
+  render: (depth: MarketDepth, frame: number, groupBy: number, scenario: Scenario) => LadderRow[];
   destroy: () => void;
 }
 
-/** A simulated book using the same DomLadder and buildRows APIs as an application. */
+/** Independent candle and order-book views using the public buildRows helper. */
 export default function DepthLadderDemo() {
   const chartElement = useRef<HTMLDivElement>(null);
   const bookElement = useRef<HTMLDivElement>(null);
@@ -29,6 +49,7 @@ export default function DepthLadderDemo() {
   const [frame, setFrame] = useState(0);
   const [levels, setLevels] = useState(20);
   const [groupBy, setGroupBy] = useState(1);
+  const [scenario, setScenario] = useState<Scenario>('option-option');
   const [running, setRunning] = useState(true);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -37,8 +58,8 @@ export default function DepthLadderDemo() {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme !== 'light';
   const depth = useMemo(() => makeDepth(frame, levels), [frame, levels]);
-  const latest = useRef({ depth, frame, groupBy });
-  latest.current = { depth, frame, groupBy };
+  const latest = useRef({ depth, frame, groupBy, scenario });
+  latest.current = { depth, frame, groupBy, scenario };
 
   useEffect(() => {
     let cancelled = false;
@@ -59,47 +80,29 @@ export default function DepthLadderDemo() {
         });
         // Keep cleanup available even if setup fails after allocating the chart.
         instance = { render: () => [], destroy: () => chart.destroy() };
-        const series = chart.addSeries('line', {
+        const series = chart.addSeries('candlestick', {
           priceFormat: { type: 'price', minMove: TICK_SIZE },
-          style: { color: dark ? '#7dafff' : '#2f6df6', lineWidth: 2 },
         });
-        const history = Array.from({ length: 80 }, (_, index) => ({
-          time: 1700000000 + index,
-          value: 100 + Math.sin(index / 9) * 0.14,
-        }));
-        series.setData(history);
-        chart.fitContent();
-        chart.timeScale.setRightOffset(128 / chart.timeScale.barSpacing);
-        let currentGroup = latest.current.groupBy;
-        const createLadder = () => new trade.DomLadder({
-          tickSize: TICK_SIZE, groupBy: currentGroup, width: 112, maxRows: 24, rowHeight: 16,
-        });
-        let ladder = createLadder();
-        chart.addPrimitive(ladder);
-        instance.render = (book, sequence, nextGroup) => {
-          if (nextGroup !== currentGroup) {
-            // Options are constructor-only in 2.1.0; replace the attached primitive.
-            chart.removePrimitive(ladder);
-            currentGroup = nextGroup;
-            ladder = createLadder();
-            chart.addPrimitive(ladder);
+        let currentScenario: Scenario | null = null;
+        let currentFrame = -1;
+        instance.render = (book, sequence, nextGroup, nextScenario) => {
+          if (nextScenario !== currentScenario) {
+            currentScenario = nextScenario;
+            series.setData(Array.from({ length: 80 }, (_, index) => chartBar(sequence - 79 + index, nextScenario)));
+            series.priceScale().setAutoScale(true);
+            chart.fitContent();
+          } else if (sequence !== currentFrame) {
+            series.update(chartBar(sequence, nextScenario));
+            const points = series.getData();
+            if (points.length > 240) series.setData(points.slice(-160));
           }
-          series.update({ time: 1700000080 + sequence, value: book.ltp });
-          const points = series.getData();
-          if (points.length > 240) series.setData(points.slice(-160));
-          // Match the displayed price span to the row step so quantities stay legible.
-          const step = TICK_SIZE * currentGroup;
-          const centre = Math.round(book.ltp / step) * step;
-          const radius = step * 10;
-          const scale = series.priceScale();
-          scale.setAutoScale(false);
-          scale.setPriceRange({ min: centre - radius, max: centre + radius });
-          ladder.setDepth(book);
-          return trade.buildRows(book, TICK_SIZE, currentGroup);
+          currentFrame = sequence;
+          // Grouping belongs to the separate book view and never changes chart data or axes.
+          return trade.buildRows(book, TICK_SIZE, nextGroup);
         };
         runtime.current = instance;
         const current = latest.current;
-        setRows(instance.render(current.depth, current.frame, current.groupBy));
+        setRows(instance.render(current.depth, current.frame, current.groupBy, current.scenario));
         setReady(true);
       } catch (cause) {
         instance?.destroy();
@@ -122,8 +125,8 @@ export default function DepthLadderDemo() {
   }, [ready, running]);
 
   useEffect(() => {
-    if (runtime.current) setRows(runtime.current.render(depth, frame, groupBy));
-  }, [depth, frame, groupBy]);
+    if (runtime.current) setRows(runtime.current.render(depth, frame, groupBy, scenario));
+  }, [depth, frame, groupBy, scenario]);
 
   // Centre the scrollable table when its row structure changes; retain the user's
   // scroll position while quantities refresh.
@@ -149,6 +152,12 @@ export default function DepthLadderDemo() {
           <span className="depth-status">Simulated · {running ? 'updating' : 'paused'}</span>
         </div>
         <div className="depth-controls">
+          <label>Chart and ladder
+            <select value={scenario} onChange={event => setScenario(event.target.value as Scenario)} disabled={!ready}>
+              <option value="option-option">Option chart + option ladder</option>
+              <option value="spot-option">Spot chart + ATM call ladder</option>
+            </select>
+          </label>
           <label>Depth levels per side
             <select value={levels} onChange={event => setLevels(Number(event.target.value))} disabled={!ready}>
               <option value={5}>5 levels</option>
@@ -170,6 +179,7 @@ export default function DepthLadderDemo() {
         </div>
       </div>
       <div className="depth-quotes">
+        <span>Ladder <strong>NIFTY ATM CE</strong></span>
         <span>Best bid <strong className="depth-bid">{depth.bids[0].price.toFixed(2)}</strong></span>
         <span>Best ask <strong className="depth-ask">{depth.asks[0].price.toFixed(2)}</strong></span>
         <span>Source tick <strong>0.05</strong></span>
@@ -177,13 +187,13 @@ export default function DepthLadderDemo() {
       </div>
       <div className="depth-panels">
         <div className="depth-chart-panel">
-          <div className="depth-panel-label">Simulated price · bid / ask ladder at right</div>
-          <div className="depth-chart" ref={chartElement} role="img" aria-label="Simulated price chart with price-aligned depth quantities" />
+          <div className="depth-panel-label">{scenario === 'spot-option' ? 'NIFTY spot' : 'NIFTY ATM CE'} · candlesticks</div>
+          <div className="depth-chart" ref={chartElement} role="img" aria-label="Simulated candlestick chart with independent price scale" />
           {!ready && !error && <p className="depth-loading">Loading depth chart…</p>}
           {error && <p className="depth-error" role="alert">Demo error: {error}</p>}
         </div>
         <div className="depth-book-panel">
-          <div className="depth-panel-label">{rows.length} display rows · scroll to explore</div>
+          <div className="depth-panel-label">ATM call ladder · {rows.length} rows · independent scale</div>
           <div className="depth-book" ref={bookElement} tabIndex={0} aria-label="Scrollable depth rows">
             <table aria-label="Aggregated depth quantities">
               <thead><tr><th scope="col">Bid qty</th><th scope="col">Price</th><th scope="col">Ask qty</th></tr></thead>
@@ -207,6 +217,8 @@ export default function DepthLadderDemo() {
       <div className="depth-footer">
         <span>Supplied book totals: <strong className="depth-bid">{qty(totalBid)} bid</strong> · <strong className="depth-ask">{qty(totalAsk)} ask</strong></span>
         <span>Updates every 750 ms. All prices and quantities are simulated.</span>
+        <span>Ladder grouping leaves candle prices, zoom and price scale untouched. Both views have separate instrument configuration.</span>
+        <span>ATM call is an illustrative fixed contract; this demo does not select or roll live option contracts.</span>
         <span>Row prices are rounded display buckets. Grouping can place both sides in one row.</span>
         <p role="status" aria-live="polite">{selection}</p>
       </div>
@@ -233,7 +245,7 @@ export default function DepthLadderDemo() {
         .depth-error { color: #ef5350; }
         .depth-book-panel { border-left: 1px solid var(--oac-card-border); min-width: 0; }
         .depth-book { height: 380px; overflow: auto; overscroll-behavior: contain; }
-        .depth-book table { display: table; width: 100%; margin: 0; border-collapse: separate; border-spacing: 0; font-size: 12px; font-variant-numeric: tabular-nums; }
+        .depth-book table { display: table; width: 100%; margin: 0; overflow: visible; border-collapse: separate; border-spacing: 0; font-size: 12px; font-variant-numeric: tabular-nums; }
         .depth-book th, .depth-book td { width: 33.333%; height: 27px; text-align: center; padding: 0 3px; border: 0; border-bottom: 1px solid var(--oac-card-border); white-space: nowrap; }
         .depth-book thead th { position: sticky; top: 0; z-index: 1; height: 30px; background: var(--oac-card); color: var(--oac-muted); font-size: 11px; }
         .depth-book tbody th { font-weight: 500; }

--- a/website/pages/docs/depth-of-market.mdx
+++ b/website/pages/docs/depth-of-market.mdx
@@ -1,6 +1,6 @@
 ---
 title: Depth of Market
-description: A simulated real-time depth ladder with 5, 20 or 200 levels per side and configurable price aggregation.
+description: Independent candlestick and depth views, with option or spot charts and configurable ladder aggregation.
 ---
 
 import DepthLadderDemo from '../../components/DepthLadderDemo'
@@ -9,16 +9,97 @@ import DepthLadderDemo from '../../components/DepthLadderDemo'
 
 Explore a changing order book with **simulated updates every 750 ms**. Choose 5,
 20 or 200 price levels per side, pause a snapshot, and combine several ticks into
-one display row. The chart uses the published `DomLadder` primitive; the adjacent
-table uses the same `buildRows` aggregation helper.
+one display row. **The ladder has its own rows and scrolling, independent of the
+candlestick chart's price scale.** Its quantities use the published `buildRows`
+aggregation helper.
 
 <DepthLadderDemo />
 
 The source tick stays at **0.05**. Start with 20 levels and pause the demo, then
 change the display row size from 0.05 to 0.50. The number of rows falls while
-the total bid and ask quantities stay the same. Scroll the table to see levels
-outside the chart's visible price range. Selecting a quantity in the table only
-displays a message; this demo has no order connection.
+the total bid and ask quantities stay the same. The candle chart stays exactly
+where you left it, including its zoom and price scale. Scroll the ladder to
+explore the supplied book. Selecting a quantity only displays a message; this
+demo has no order connection.
+
+Use **Chart and ladder** to try either requested setup:
+
+| Setup | Candlestick chart | Independent ladder |
+|---|---|---|
+| Option chart + option ladder | Illustrative NIFTY ATM call, normal price scale | The same option, with 0.05–1.00 display rows |
+| Spot chart + ATM call ladder | Illustrative NIFTY spot, around 24,000 | An option around 100, with its own display grouping |
+
+All data in these two scenarios is simulated. The ATM call label represents a
+fixed illustrative contract; automatic strike selection, expiry selection and
+contract rollover are not part of this demo.
+
+## Keep the chart and ladder independent
+
+Use a separate table or panel for a ladder whose grouping or instrument differs
+from the chart. `buildRows` only aggregates a supplied book: it does not read or
+change a chart's price axis. The demo previously set the chart's price range from
+the ladder row size; that coupling has been removed.
+
+The following example uses the existing 2.1.0 API. Give `chart` a height and put a
+`<tbody id="book-rows">` in a separate scrollable table with bid, price and ask
+column headings:
+
+```ts
+import { createChart } from 'openalgo-charts';
+import { buildRows } from 'openalgo-charts/trade';
+import type { Bar, MarketDepth } from 'openalgo-charts';
+
+const chart = createChart(document.getElementById('chart')!);
+const candles = chart.addSeries('candlestick');
+const bookRows = document.getElementById('book-rows')!;
+const ladderTick = 0.05;
+let groupBy = 10; // Independent 0.50 display rows.
+let latestDepth: MarketDepth = { bids: [], asks: [], ltp: 0 };
+
+function onChartHistory(bars: Bar[]) {
+  candles.setData(bars);
+  chart.fitContent();
+}
+
+function onChartBar(bar: Bar) {
+  candles.update(bar);
+}
+
+function onOptionDepth(depth: MarketDepth) {
+  latestDepth = depth;
+  bookRows.replaceChildren(...buildRows(depth, ladderTick, groupBy).map(row => {
+    const tr = document.createElement('tr');
+    for (const text of [String(row.bidQty), row.price.toFixed(2), String(row.askQty)]) {
+      const td = document.createElement('td');
+      td.textContent = text;
+      td.style.height = '28px';
+      tr.append(td);
+    }
+    return tr;
+  }));
+}
+
+function setLadderGrouping(ticksPerRow: number) {
+  if (!Number.isInteger(ticksPerRow) || ticksPerRow < 1) {
+    throw new Error('Grouping must be a positive integer number of source ticks.');
+  }
+  groupBy = ticksPerRow;
+  onOptionDepth(latestDepth);
+}
+
+// Connect chart history/live bars and option depth to their own feed subscriptions.
+// For a spot chart, route spot bars here and the chosen option's book to onOptionDepth.
+// On teardown, unsubscribe both feeds, then call chart.destroy().
+```
+
+For an application, keep separate chart and ladder instrument identifiers,
+source tick sizes, display settings and feed subscriptions. For a spot chart
+with an ATM option ladder, resolve a concrete option symbol and expiry in your
+host application. On a contract change, unsubscribe the previous book, clear its
+rows, subscribe to the new contract and ignore late messages from the old
+subscription. Show the selected strike/expiry and a feed timestamp beside the
+ladder. Consider keeping the selected contract fixed during inspection and
+making ATM reselection explicit, so rows do not suddenly switch instruments.
 
 ## Source ticks and display grouping
 
@@ -43,10 +124,11 @@ That row label is an aggregation bucket, not an executable quote. The best bid
 and ask above the demo come from the ungrouped supplied book. Empty price levels
 are not invented or filled in between the supplied levels.
 
-## Add a ladder
+## Attach a price-aligned ladder instead
 
-The ladder is available in the trade tier. The following code uses the published
-2.1.0 API:
+`DomLadder` is an alternative when the book should align to the **same instrument
+and price scale** as its chart. It is available in the trade tier. The following
+code uses the published 2.1.0 API:
 
 ```ts
 import { createChart } from 'openalgo-charts';
@@ -109,7 +191,7 @@ groupedLadder.setDepth(depth);
 // Route subsequent snapshots to groupedLadder.
 ```
 
-For a separate table, use the same public helper:
+The independent demo uses the same public helper without attaching a primitive:
 
 ```ts
 import { buildRows } from 'openalgo-charts/trade';
@@ -120,13 +202,18 @@ const rows = buildRows(depth, 0.05, 10);
 
 ## Rendering and data limits
 
-The ladder is docked inside the chart's right edge and aligns quantities to its
+The attached `DomLadder` primitive is docked inside the chart's right edge and aligns quantities to its
 price scale. Its canvas displays rows in the visible price range, capped by
 `maxRows`; it does not automatically fit all supplied depth. Zoom or adjust the
-price scale to inspect a different range. The demo adjusts its price span when
-the grouping changes and centres the viewport on the nearest display bucket.
-Raw tick movements inside that bucket update quantities without shifting the
-ladder vertically. Its simulated price history is bounded to 240 points.
+price scale to inspect a different range. `rowHeight` controls the drawn row's
+height; it does not create an independent price scale. Grouping the primitive
+does not itself rescale the chart, although adjacent grouped prices can overlap
+when the chart's price scale places them too close together.
+
+The independent demo above uses a scrollable table with fixed-height rows, so
+every supplied aggregated row remains accessible at any chart zoom. Its
+simulated candle history is bounded to 240 bars. For much deeper books, a host
+can virtualize this table while continuing to use `buildRows` for aggregation.
 
 `ladder.tier()` reports `none` for an empty book, `compact` for up to five levels
 per side, and `deep` for larger snapshots. Passing empty bid and ask arrays clears


### PR DESCRIPTION
Changing the depth demo's display row size previously widened the candle chart's price range. The demo now renders its book in an independent scrollable table using `buildRows`, preserving candle data, zoom and price scaling when grouping or depth levels change.

Adds both setups requested in #6: option candles with the same option's ladder, and spot candles with a separate illustrative ATM call ladder. Candles autoscale when switching instruments, including after a manual price-axis adjustment. Both scenarios use explicitly simulated data. README and guide explain independent feed/configuration ownership, the existing price-aligned `DomLadder` alternative, and host-side option-contract selection.

Validation: website production build and lint passed; browser regression checks fail on the original scaling behavior and pass on the updated static export. Checks cover chart pixel stability under grouping (including manual axis zoom), spot/option switching, quantity totals, 5/20/200 levels, pause/resume, sticky headers, light/dark themes, mobile layout and timer cleanup. The browser check now runs in the docs CI job.

Addresses the follow-up in https://github.com/marketcalls/openalgo-charts/issues/6#issuecomment-5567963978. Uses the existing 2.1.0 library API; no npm release required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the depth demo's DOM grouping independent of the candle chart, so changing display row size no longer rescales the chart. Adds both requested setups from #6: option candles with the same option's ladder, and spot candles with a separate ATM call ladder.

**What changed**
- The demo now renders the order book in a scrollable table using `buildRows`, leaving candle data, zoom, and price scaling untouched.
- Candles autoscale when switching instruments, including after a manual price-axis adjustment.
- Both scenarios use explicitly simulated data; README and the depth-of-market guide explain independent feed/configuration ownership, the existing `DomLadder` alternative, and host-side option-contract selection.
- CI now runs browser checks that verify chart pixel stability under grouping, spot/option switching, quantity totals, 5/20/200 levels, pause/resume, sticky headers, light/dark themes, mobile layout, and timer cleanup.

<sup>Written for commit d47dbe6dcca4e3376638422e554911b155703d90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo-charts/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

